### PR TITLE
resolve AI-Planning/planutils/#2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,69 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/bionic64"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 3
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update && apt-get install --no-install-recommends -y \
+        bison \
+        build-essential \
+        ca-certificates \
+        cmake \
+        cryptsetup \
+        curl \
+        flex \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libgpgme11-dev \
+        libseccomp-dev \
+        libssl-dev \
+        locales \
+        pkg-config \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        scons \
+        software-properties-common \
+        squashfs-tools \
+        tzdata \
+        unzip \
+        uuid-dev \
+        vim \
+        wget
+
+    pip3 install --upgrade pip
+
+    # install go to build singularity
+    export VERSION=1.13 OS=linux ARCH=amd64
+    wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz
+    tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz
+    rm go$VERSION.$OS-$ARCH.tar.gz
+    export GOPATH="${HOME}/go"
+    export PATH="/usr/local/go/bin:${PATH}:${GOPATH}/bin"
+
+    # get a recent version of singularity
+    export VERSION=3.5.0
+    wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+    tar -xzf singularity-${VERSION}.tar.gz
+    cd singularity
+    ./mconfig
+    make -C ./builddir
+    make -C ./builddir install
+    cd ..
+    rm -rf singularity
+    rm singularity-${VERSION}.tar.gz
+    echo '. /usr/local/etc/bash_completion.d/singularity' >> /home/vagrant/.bashrc
+
+    # install & setup the planutils for the vagrant user
+    runuser -l vagrant -c "pip3 install --user planutils --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+    runuser -l vagrant -c "planutils --setup"
+SHELL
+
+  config.ssh.forward_x11 = true
+  config.ssh.forward_agent = true
+end


### PR DESCRIPTION
Is this what you had in mind? I wasn't sure how to handle the comments from `Vagrantfile.issues`:

- install VAL: I guess that should be done through planutils, not in the vagrantfile
- install SoPlex: same as above, also I assume there are licensing issues
- install scip: not interesting without SoPlex
- install Prost: should be done through planutils
- install minisat: only relevant for our exercise sessions
- trouble with 2GB memory limit: I'm not sure what a good setting there is, as this depends on the host computer
- trouble running vagrant on Windows: was mostly related to specific known problems that we cannot do anything about.
