### PR TITLE
use multiple stages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         bash-completion \
         ca-certificates \
-        curl \
         git \
         libseccomp-dev \
         python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,15 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         bash-completion \
         ca-certificates \
+        curl \
+        git \
         libseccomp-dev \
         python3 \
         python3-pip \
         python3-venv \
         squashfs-tools \
         tzdata \
+        unzip \
         vim \
         wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The current Dockerfile leads to a 1.5 GiB container and this patch cuts that down to 300 MiB. There are a couple of things I changed, some more controversial than others:

1. multi-stage build
The build is now done in two stages: the first builds singularity, the next copies it from the first. This way, you don't end up with go installed in the main container. It also means some build tools are no longer required.

2. golang container
The build now uses golang container instead of installing go from source. The advantage is that we don't have to care about the details of installing go and don't need its dependencies. We could go further in this direction by also not installing singularity from source but instead use the latest "slim" container from here https://github.com/singularityhub/singularity-docker I didn't do this so far but it might be worth a thought.

3. apt-get steps
One "trick" that is done quite often on Dockerfiles is to bundle `apt-get update`, `apt-get install` and `rm -rf /var/lib/apt/lists/*` into a single step. The point of that is that every `RUN` step in docker creates a new layer. The final image size is the sum of all layer sizes, so downloading the package info in one layer and deleting it in a later layer still uses the full space of it. Bundling the steps into one saves a bit of space over all.

4. removed packages
I wasn't clear on which packages where meant for the user and which where just dependencies. I removed a lot of non-essential packages where I thought they are not needed (hoping you'd correct me if I removed too much). For example, `flex` and `bison` where maybe thought for VAL, but VAL could also be build in a separate build stage or installed as a binary or singularity image and doesn't need those packages then. The remaining non-essential packages are `bash-completion`, `vim` and `wget` to make working inside the container more pleasant. I also left `python3-venv` which I assume was meant for lab? Though I'm not sure if this make sense because running experiments from inside the container is not ideal.