### PR TITLE
Bump singularity version for kernel compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive  apt-get install --no-insta
     uuid-dev \
     wget
 
-ENV VERSION=3.5.0
-RUN wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz
-RUN tar -xzf singularity-${VERSION}.tar.gz
-WORKDIR /go/singularity
+ENV VERSION=3.5.2
+RUN git clone https://github.com/sylabs/singularity.git
+WORKDIR singularity
+RUN git checkout v${VERSION}
 RUN ./mconfig -p /usr/local/singularity
 RUN make -C ./builddir
 RUN make -C ./builddir install


### PR DESCRIPTION
The current docker image doesn't work for me. I get errors like this for any of the planners I've tried:

`FATAL:   container creation failed: mount /proc/self/fd/3->/usr/local/singularity/var/singularity/mnt/session/rootfs error: while mounting image /proc/self/fd/3: kernel reported a bad superblock for squashfs image partition, possible causes are that your kernel doesn't support the compression algorithm or the image is corrupted`

I found that this is a known incompatibility between v3.5.0 of singularity and the default kernel of ubuntu 18.04. https://github.com/hpcng/singularity/issues/5466

Updating to v3.5.2 and rebuilding the image worked for me.