### PR TITLE
Add "run" command.

### DIFF
--- a/planutils/__init__.py
+++ b/planutils/__init__.py
@@ -1,6 +1,5 @@
 
-import argparse
-import os
+import argparse, os
 from pathlib import Path
 
 from planutils import settings
@@ -14,10 +13,7 @@ def minimal_setup():
         print(f"Creating {planutils_dir}...")
         planutils_dir.mkdir()
         os.symlink(script_dir / "packages", planutils_dir / "packages")
-
-        settings.save({
-            'installed': []
-        })
+        settings.save({'installed': []})
 
 
 def setup():
@@ -29,18 +25,8 @@ def setup():
         else:
             return
 
-    CUR_DIR = os.path.dirname(os.path.abspath(__file__))
-
-    print("\nCreating ~/.planutils...")
-    os.mkdir(os.path.join(os.path.expanduser('~'), '.planutils'))
+    minimal_setup()
     os.mkdir(os.path.join(os.path.expanduser('~'), '.planutils', 'bin'))
-
-    settings.save({
-        'installed': []
-    })
-
-    os.symlink(os.path.join(CUR_DIR, 'packages'),
-               os.path.join(os.path.expanduser('~'), '.planutils', 'packages'))
 
     print("Adding bin folder to path (assuming ~/.bashrc exists)...")
     with open(os.path.join(os.path.expanduser('~'), '.bashrc'), "a+") as f:

--- a/planutils/__init__.py
+++ b/planutils/__init__.py
@@ -1,8 +1,23 @@
 
-import argparse, os
+import argparse
+import os
+from pathlib import Path
 
 from planutils import settings
 from planutils.package_installation import PACKAGES
+
+
+def minimal_setup():
+    cur_dir = Path(__file__).resolve().parent
+    planutils_dir = (Path.home() / ".planutils")
+    if not planutils_dir.is_dir():
+        print(f"Creating {planutils_dir}...")
+        planutils_dir.mkdir()
+        os.symlink(cur_dir / "packages", planutils_dir / "packages")
+
+        settings.save({
+            'installed': []
+        })
 
 
 def setup():
@@ -92,10 +107,10 @@ def main():
 
     args = parser.parse_args()
 
+    minimal_setup()
+
     if 'setup' == args.command:
         setup()
-    elif not setup_done():
-        print("\nPlease run 'planutils setup' before using utility.\n")
 
     elif 'check-installed' == args.command:
         from planutils.package_installation import check_installed

--- a/planutils/__init__.py
+++ b/planutils/__init__.py
@@ -8,12 +8,12 @@ from planutils.package_installation import PACKAGES
 
 
 def minimal_setup():
-    cur_dir = Path(__file__).resolve().parent
-    planutils_dir = (Path.home() / ".planutils")
+    script_dir = Path(__file__).resolve().parent
+    planutils_dir = Path(settings.PLANUTILS_PREFIX)
     if not planutils_dir.is_dir():
         print(f"Creating {planutils_dir}...")
         planutils_dir.mkdir()
-        os.symlink(cur_dir / "packages", planutils_dir / "packages")
+        os.symlink(script_dir / "packages", planutils_dir / "packages")
 
         settings.save({
             'installed': []
@@ -98,6 +98,10 @@ def main():
     parser_uninstall = subparsers.add_parser('uninstall', help='uninstall package(s)')
     parser_uninstall.add_argument('package', help='package name', nargs='+')
 
+    parser_run = subparsers.add_parser('run', help='run package')
+    parser_run.add_argument('package', help='package name')
+    parser_run.add_argument('options', help='commandline options for the package', nargs="*")
+
     parser_checkinstalled = subparsers.add_parser('check-installed', help='check if a package is installed')
     parser_checkinstalled.add_argument('package', help='package name')
 
@@ -123,6 +127,10 @@ def main():
     elif 'uninstall' == args.command:
         from planutils.package_installation import uninstall
         uninstall(args.package)
+
+    elif 'run' == args.command:
+        from planutils.package_installation import run
+        run(args.package, args.options)
 
     elif 'list' == args.command:
         from planutils.package_installation import package_list

--- a/planutils/package_installation.py
+++ b/planutils/package_installation.py
@@ -1,6 +1,7 @@
 
-import json, os, glob, subprocess
+import json, os, glob, subprocess, sys
 from collections import defaultdict
+from pathlib import Path
 
 from planutils import settings
 
@@ -177,3 +178,9 @@ def install(targets, forced=False):
 
     return False
 
+def run(target, options):
+    if target not in PACKAGES:
+        sys.exit(f"Package {target} is not installed")
+    if not PACKAGES[target]["runnable"]:
+        sys.exit(f"Package {target} is not executable")
+    subprocess.run([Path(settings.PLANUTILS_PREFIX) / "packages" / target / "run"] + options)

--- a/planutils/package_installation.py
+++ b/planutils/package_installation.py
@@ -178,6 +178,7 @@ def install(targets, forced=False):
 
     return False
 
+
 def run(target, options):
     if target not in PACKAGES:
         sys.exit(f"Package {target} is not installed")

--- a/planutils/packages/lama-first/run
+++ b/planutils/packages/lama-first/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-downward --alias lama-first $@
+planutils run downward -- --alias lama-first $@

--- a/planutils/packages/lama/run
+++ b/planutils/packages/lama/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-downward --alias lama $@
+planutils run downward -- --alias lama $@


### PR DESCRIPTION
As discussed in #14 this patch adds a "run" command for executing planners. This makes it possible to use planutils without changing the PATH variable. All existing commands ("install", "list", etc.) still work as intended.