### PR TITLE
update smtplan image host #86

### DIFF
--- a/planutils/packages/smtplan/install
+++ b/planutils/packages/smtplan/install
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-
-## Fetch the image
-singularity pull --name smtplan.sif library://jdekarske/default/smtplan:latest 
+singularity pull --name smtplan.sif docker://ghcr.io/jdekarske/smtplan:latest

--- a/planutils/packages/smtplan/run
+++ b/planutils/packages/smtplan/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-singularity run -e $(dirname $0)/smtplan.sif $@
+singularity run -e $(dirname $0)/smtplan.sif /SMTPlan $@


### PR DESCRIPTION
This should fix the `library://` issue since the image was originally hosted on Sylabs.

Container workflow [here](https://github.com/jdekarske/SMTPlan/blob/workflows/.github/workflows/push_image.yml)

Container image [here](https://github.com/jdekarske/SMTPlan/pkgs/container/smtplan)