### PR TITLE
Install Fast Downward through docker

### DIFF
--- a/planutils/packages/downward/install
+++ b/planutils/packages/downward/install
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-singularity pull --name downward.sif shub://aibasel/downward
+apptainer build downward.sif docker://aibasel/downward:latest


### PR DESCRIPTION
This will install the latest Fast Downward from dockerhub. It will take longer than the previous build (which just downloaded the file from singularity hub) but it will always get the latest release, while we would have to update links to get new releases as singularity images.