### PR TITLE
Moved images of symk and scorpion from sylabs.io to ghcr.io

### DIFF
--- a/planutils/packages/scorpion/install
+++ b/planutils/packages/scorpion/install
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-singularity pull scorpion.sif library://jendrikseipp/default/scorpion:latest
+singularity pull scorpion.sif oras://ghcr.io/jendrikseipp/scorpion:latest

--- a/planutils/packages/symk/install
+++ b/planutils/packages/symk/install
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-singularity pull --name symk.sif library://speckdavid/symk/symk:latest
+singularity pull symk.sif oras://ghcr.io/speckdavid/symk:latest


### PR DESCRIPTION
Moved images of symk and scorpion from sylabs.io to ghcr.io .

Note: The change to the scorpion image is on behalf of Jendrik Seipp.