### PR TITLE
Overhaul the user interface

### DIFF
--- a/bin/planutils
+++ b/bin/planutils
@@ -8,7 +8,7 @@ if [ "$1" = "activate" ]; then
     export PATH="$PATH:$PLANUTILS_PREFIX/bin"
 
     # Add a blue coloured shell prompt prefix (planutils)
-    export PS1="(\e[1;34mplanutils\e[0m) $PS1"
+    export PS1="(\[\e[1;34m\]planutils\[\e[0m\]) $PS1"
 
     echo
     echo "   Entering planutils environment..."
@@ -22,3 +22,5 @@ else
     python3 -c "import planutils; planutils.main()" "$@"
 fi
 
+# Clear history
+history -cw

--- a/planutils/__init__.py
+++ b/planutils/__init__.py
@@ -103,6 +103,9 @@ def main():
     parser_setup = subparsers.add_parser('setup', help='setup planutils for current user')
     parser_upgrade = subparsers.add_parser('upgrade', help='upgrade all of the installed packages')
 
+    parser_show = subparsers.add_parser('show', help='show details about a particular package')
+    parser_show.add_argument('package', help='package name', nargs='+')
+
     args = parser.parse_args()
 
     if 'setup' == args.command:
@@ -146,6 +149,10 @@ def main():
     elif 'server' == args.command:
         from planutils.server import run_server
         run_server(args.port, args.host)
+
+    elif 'show' == args.command:
+        from planutils.package_installation import package_info
+        package_info(args.package)
 
     else:
         parser.print_help()

--- a/planutils/__init__.py
+++ b/planutils/__init__.py
@@ -30,6 +30,9 @@ def setup():
 
     print("Installing package scripts...")
     for p in PACKAGES:
+        # TODO: RENAME EXECUTABLE HERE
+        try: s = PACKAGES[p]['shortname']
+        except: s = p
         if PACKAGES[p]['runnable']:
             script  = "#!/bin/bash\n"
             script += "if $(planutils check-installed %s)\n" % p
@@ -57,9 +60,9 @@ def setup():
             script += "  fi\n"
             script += "  echo\n"
             script += "fi\n"
-            with open(os.path.join(os.path.expanduser('~'), '.planutils', 'bin', p), 'w') as f:
+            with open(os.path.join(os.path.expanduser('~'), '.planutils', 'bin', s), 'w') as f:
                 f.write(script)
-            os.chmod(os.path.join(os.path.expanduser('~'), '.planutils', 'bin', p), 0o0755)
+            os.chmod(os.path.join(os.path.expanduser('~'), '.planutils', 'bin', s), 0o0755)
 
 
     print("\nAll set! Use \"planutils activate\" to activate the environment, or run through \"planutils\" directly.\n")

--- a/planutils/package_installation.py
+++ b/planutils/package_installation.py
@@ -97,11 +97,11 @@ def uninstall(targets):
 def package_list():
     print("\nInstalled:")
     installed = set(settings.load()['installed'])
-    for p in installed:
+    for p in sorted(installed):
         print("  %s: %s" % (p, PACKAGES[p]['name']))
 
     print("\nAvailable:")
-    for p in PACKAGES:
+    for p in sorted(PACKAGES):
         if p not in installed:
             print("  %s: %s" % (p, PACKAGES[p]['name']))
     print()

--- a/planutils/package_installation.py
+++ b/planutils/package_installation.py
@@ -106,8 +106,7 @@ def package_list():
     installed_names = []
 
     terminal_width = 120
-    #https://www.geeksforgeeks.org/python-extract-length-of-longest-string-in-list
-    width_name = max(len(ele) for ele in PACKAGES)
+    width_name = 20
     width_desc = terminal_width - (width_name + 1)
 
     if installed:

--- a/planutils/package_installation.py
+++ b/planutils/package_installation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from planutils import settings
 
 PACKAGES = {}
+ALIASES = {}
 
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -25,6 +26,8 @@ for conf_file in glob.glob(os.path.join(CUR_DIR, 'packages', '*')):
         check_package(base, os.path.join(conf_file, 'manifest.json'))
         with open(os.path.join(conf_file, 'manifest.json'), 'r') as f:
             config = json.load(f)
+        try: ALIASES[config['shortname']] = base
+        except: pass
         PACKAGES[base] = config
         PACKAGES[base]['runnable'] = os.path.exists(os.path.join(conf_file, 'run'))
 
@@ -36,12 +39,16 @@ def check_installed(target):
 def uninstall(targets):
 
     for target in targets:
+        try: target = ALIASES[target]
+        except: pass
         if target not in PACKAGES:
             print("Error: Package not found -- %s" % target)
             return
 
     to_check = []
     for target in targets:
+        try: target = ALIASES[target]
+        except: pass
         if check_installed(target):
             to_check.append(target)
         else:
@@ -105,7 +112,8 @@ def package_list():
 
     if installed:
         for p in installed:
-            installed_names.append(p)
+            try: installed_names.append(PACKAGES[p]['shortname'])
+            except: installed_names.append(p)
         print("%-*s %s" % (width_name, 'Installed', 'Summary'))
         print("%-*s %s" % (width_name, ''.ljust(width_name,'-'), ''.ljust(width_desc,'-')))
         for p in sorted(installed_names):
@@ -121,7 +129,8 @@ def package_list():
         print("%-*s %s" % (width_name, ''.ljust(width_name,'-'), ''.ljust(width_desc,'-')))
         for p in sorted(available_names):
             if p not in installed_names:
-                print("%-*s %s" % (width_name, p, PACKAGES[p]['name']))
+                try: print("%-*s %s" % (width_name, p, PACKAGES[p]['name']))
+                except: print("%-*s %s" % (width_name, p, PACKAGES[ALIASES[p]]['name']))
 
 def upgrade():
     s = settings.load()
@@ -132,6 +141,8 @@ def upgrade():
 
 def package_info(targets):
     for target in targets:
+        try: target = ALIASES[target]
+        except: pass
         if target not in PACKAGES:
             print("Error: Package not found -- %s" % target)
             return
@@ -148,6 +159,8 @@ def package_info(targets):
 
 def install(targets, forced=False, always_yes=False):
     for target in targets:
+        try: target = ALIASES[target]
+        except: pass
         if target not in PACKAGES:
             print("Error: Package not found -- %s" % target)
             return False
@@ -155,6 +168,8 @@ def install(targets, forced=False, always_yes=False):
     # Compute all those that will need to be installed
     to_check = []
     for target in targets:
+        try: target = ALIASES[target]
+        except: pass
         if check_installed(target):
             if forced:
                 to_check.append(target)
@@ -173,12 +188,16 @@ def install(targets, forced=False, always_yes=False):
             done.add(check)
             if not check_installed(check):
                 to_install.append(check)
-                to_check.extend(PACKAGES[check]['dependencies'])
+                try: to_check.extend(PACKAGES[ALIASES[check]]['dependencies'])
+                except: to_check.extend(PACKAGES[check]['dependencies'])
 
     to_install.reverse()
 
     if to_install:
-        to_install_desc = ["%s (%s)" % (pkg, PACKAGES[pkg]['install-size']) for pkg in to_install]
+        to_install_desc = []
+        for pkg in to_install:
+            try: to_install_desc.append("%s (%s)" % (pkg, PACKAGES[ALIASES[pkg]]['install-size']))
+            except: to_install_desc.append("%s (%s)" % (pkg, PACKAGES[pkg]['install-size']))
         print("\nAbout to install the following packages: %s" % ', '.join(to_install_desc))
 
         if always_yes:
@@ -189,6 +208,8 @@ def install(targets, forced=False, always_yes=False):
         if user_response:
             installed = []
             for package in to_install:
+                try: package = ALIASES[package]
+                except: pass
                 package_path = os.path.join(CUR_DIR, 'packages', package)
                 print("Installing %s..." % package)
                 try:
@@ -218,6 +239,8 @@ def install(targets, forced=False, always_yes=False):
 
 
 def run(target, options):
+    try: target = ALIASES[target]
+    except: pass
     if target not in PACKAGES:
         sys.exit(f"Package {target} not found")
     if not check_installed(target):

--- a/planutils/packages/cerberus-agl/manifest.json
+++ b/planutils/packages/cerberus-agl/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "Cerberus planner for agile planning",
-    "description": "https://github.com/ctpelok77/fd-red-black-postipc2018",
+    "name": "Cerberus -- agile planner, post-IPC18 version",
+    "description": "The configuration runs only the first iteration of the satisficing configurration, which is a greedy best-first search (GBFS) with deferred heuristic evaluation.",
     "install-size": "20K",
     "dependencies": ["cerberus"]
 }

--- a/planutils/packages/cerberus-sat/manifest.json
+++ b/planutils/packages/cerberus-sat/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Cerberus planner for satisficing planning",
-  "description": "https://github.com/ctpelok77/fd-red-black-postipc2018",
+  "name": "Cerberus -- satisficing planner, post-IPC18 version",
+  "description": "The configuration runs a sequence of search iterations of decreasing level of greediness. In case a solution is found in the previous iteration, its cost is passed as a pruning bound to the next iteration.",
   "install-size": "20K",
   "dependencies": ["cerberus"],
   "endpoint": {

--- a/planutils/packages/cerberus/manifest.json
+++ b/planutils/packages/cerberus/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Cerberus planners for satisficing and agile planning",
-    "description": "https://github.com/ctpelok77/fd-red-black-postipc2018",
+    "name": "Cerberus: a red-black planning system",
+    "description": "Cerberus, built on top of Mercury, is a planner which makes use of a red-black heuristic together with the introduction of novelty based heuristic guidance and enhanced mutual exclusion detection.",
+    "homepage": "https://github.com/ctpelok77/fd-red-black-postipc2018",
     "install-size": "38M",
     "dependencies": []
 }

--- a/planutils/packages/cpor/manifest.json
+++ b/planutils/packages/cpor/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "CPOR",
-    "description": "CPOR: Contingent Planning using On-line Replanning (for any issues, please email Guy Shani <shanigu@bgu.ac.il>)",
+    "name": "CPOR: Contingent Planning using On-line Replanning",
+    "description": " For any issues, please email Guy Shani <shanigu@bgu.ac.il>",
+    "homepage": "https://github.com/aiplan4eu/up-cpor",
     "install-size": "51M",
     "dependencies": []
 }

--- a/planutils/packages/delfi/manifest.json
+++ b/planutils/packages/delfi/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "Delfi1 cost-optimal planner, winner of IPC2018",
-  "description": "https://bitbucket.org/ipc2018-classical/team23/src/ipc-2018-seq-opt/",
+  "name": "Delfi: online planner selection for cost-optimal planning",
+  "description": "This planner uses an offline learned algorithm selector based on a abstract structure graph of the PDDL description of the planning task.",
+  "homepage": "https://bitbucket.org/ipc2018-classical/team23/src/ipc-2018-seq-opt",
   "install-size": "652M",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/downward/manifest.json
+++ b/planutils/packages/downward/manifest.json
@@ -1,5 +1,6 @@
 {
     "name": "The Fast Downward (FD) planning system",
+    "shortname": "fd",
     "description": "A classical planning system based on heuristic search. Since its first release in 2004, many parts have been added, including optimal planning, support for action costs, and many more heuristics.",
     "homepage": "http://fast-downward.org",
     "install-size": "36M",

--- a/planutils/packages/downward/manifest.json
+++ b/planutils/packages/downward/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Fast Downward",
-    "description": "http://fast-downward.org/",
+    "name": "The Fast Downward (FD) planning system",
+    "description": "A classical planning system based on heuristic search. Since its first release in 2004, many parts have been added, including optimal planning, support for action costs, and many more heuristics.",
+    "homepage": "http://fast-downward.org",
     "install-size": "36M",
     "dependencies": []
 }

--- a/planutils/packages/dual-bfws-fdparser/manifest.json
+++ b/planutils/packages/dual-bfws-fdparser/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Best First Width Search (BFWS)",
-  "description": "This package contains the source code of the planners that participated in IPC-9, 2018. It contains the winner of the Agile-Track, and runner-up of tha SAT-track.",
+  "name": "BFWS -- FD-parser version",
+  "description": "This package contains the FD parser version of the Best First Width Search planner.",
   "install-size": "0M",
   "dependencies": ["lapkt"],
   "endpoint": {

--- a/planutils/packages/dual-bfws-fdparser/manifest.json
+++ b/planutils/packages/dual-bfws-fdparser/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "BFWS -- FD-parser version",
+  "shortname": "bfws-fd",
   "description": "This package contains the FD parser version of the Best First Width Search planner.",
   "install-size": "0M",
   "dependencies": ["lapkt"],

--- a/planutils/packages/dual-bfws-fdparser/run
+++ b/planutils/packages/dual-bfws-fdparser/run
@@ -1,2 +1,7 @@
 #!/bin/bash
-lapkt python3 /planner/BFWS/fd-version/bfws.py $@
+
+DOMAIN=$1
+PROBLEM=$2
+shift 2
+
+planutils run lapkt -- python3 /planner/BFWS/fd-version/bfws.py $DOMAIN $PROBLEM plan $@

--- a/planutils/packages/dual-bfws-ffparser/manifest.json
+++ b/planutils/packages/dual-bfws-ffparser/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "BFWS -- FF-parser version",
+  "shortname": "bfws-ff",
   "description": "This package contains the FF parser version of the Best First Width Search planner.",
   "install-size": "0M",
   "dependencies": ["lapkt"],

--- a/planutils/packages/dual-bfws-ffparser/manifest.json
+++ b/planutils/packages/dual-bfws-ffparser/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Best First Width Search (BFWS)",
-  "description": "This package contains the source code of the planners that participated in IPC-9, 2018. It contains the winner of the Agile-Track, and runner-up of tha SAT-track.",
+  "name": "BFWS -- FF-parser version",
+  "description": "This package contains the FF parser version of the Best First Width Search planner.",
   "install-size": "0M",
   "dependencies": ["lapkt"],
   "endpoint": {

--- a/planutils/packages/dual-bfws-ffparser/run
+++ b/planutils/packages/dual-bfws-ffparser/run
@@ -1,2 +1,7 @@
 #!/bin/bash
-lapkt /planner/BFWS/ff-version/bfws --domain $1 --problem $2 --output $3
+
+DOMAIN=$1
+PROBLEM=$2
+shift 2
+
+planutils run lapkt -- /planner/BFWS/ff-version/bfws --domain $DOMAIN --problem $PROBLEM --output plan $@

--- a/planutils/packages/enhsp-2018/manifest.json
+++ b/planutils/packages/enhsp-2018/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "ENHSP (2018)",
-    "description": "Expressive Numeric Heuristic Search Planner (https://gitlab.com/enricos83/ENHSP-Public)",
+    "name": "ENHSP -- 2018 version",
+    "description": "First version of ENHSP. Last updated 2018.",
     "install-size": "106M",
     "dependencies": []
 }

--- a/planutils/packages/enhsp-2019/manifest.json
+++ b/planutils/packages/enhsp-2019/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "ENHSP (2019)",
-    "description": "Expressive Numeric Heuristic Search Planner (https://gitlab.com/enricos83/ENHSP-Public)",
+    "name": "ENHSP -- 2019 version",
+    "description": "Stable version, contains all functionalities of ENHSP-18, with bug fixes and new data structures. Last updated May 2020.",
+    "homepage": "https://gitlab.com/enricos83/ENHSP-Public",
     "install-size": "162M",
     "dependencies": []
 }

--- a/planutils/packages/enhsp-2020/manifest.json
+++ b/planutils/packages/enhsp-2020/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "ENHSP (2020)",
-  "description": "Expressive Numeric Heuristic Search Planner (https://gitlab.com/enricos83/ENHSP-Public)",
+  "name": "ENHSP -- 2020 version",
+  "description": "This version contains the new relaxed plan-based heuristics developed for ICAPS-20 and substantial refactoring. Constant updates.",
+  "homepage": "https://gitlab.com/enricos83/ENHSP-Public",
   "install-size": "86M",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/enhsp/manifest.json
+++ b/planutils/packages/enhsp/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "ENHSP",
-    "description": "Expressive Numeric Heuristic Search Planner (https://gitlab.com/enricos83/ENHSP-Public)",
+    "name": "ENHSP: Expressive Numeric Heuristic Search Planner",
+    "description": "Supports classical and numeric planning (PDDL2.1), optimal simple numeric planning, satisficing non-linear numeric planning, autonomous processes and discrete events (PDDL+), and more.",
+    "homepage": "https://sites.google.com/view/enhsp",
     "install-size": "20K",
     "dependencies": ["enhsp-2019"]
 }

--- a/planutils/packages/ff/manifest.json
+++ b/planutils/packages/ff/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "Fast-Forward",
-  "description": "https://fai.cs.uni-saarland.de/hoffmann/ff.html",
+  "name": "The Fast-Forward (FF) planning system",
+  "description": "Fast-Forward is forward-chaining, domain-independent planning system that can handle classical STRIPS- as well as full scale ADL- planning tasks specified in PDDL.",
+  "homepage": "https://fai.cs.uni-saarland.de/hoffmann/ff.html",
   "install-size": "1.1M",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/fond4ltlf/manifest.json
+++ b/planutils/packages/fond4ltlf/manifest.json
@@ -1,7 +1,7 @@
 {
-    "name": "FOND4LTLf",
-    "description": "FOND4LTLf is a tool that compiles Fully Observable Non-Deterministic (FOND) planning problems with temporally extended goals, specified either in LTLf or in PLTLf, into standard FOND planning problems.",
+    "name": "FOND 4 LTLf",
+    "description": "A tool that compiles Fully Observable Non-Deterministic (FOND) planning problems with temporally extended goals, specified either in LTLf or in PLTLf, into standard FOND planning problems.",
+    "homepage": "https://github.com/whitemech/FOND4LTLf",
     "install-size": "278.3M",
     "dependencies": []
 }
-

--- a/planutils/packages/forbiditerative-diverse-agl/manifest.json
+++ b/planutils/packages/forbiditerative-diverse-agl/manifest.json
@@ -1,5 +1,6 @@
 {
     "name": "FI -- diverse agile planner",
+    "shortname": "fi-div-agl",
     "description": "Diverse planning focuses on producing sets of plans with a large difference between individual plans. Agile (greedy) configuration.",
     "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "20K",

--- a/planutils/packages/forbiditerative-diverse-agl/manifest.json
+++ b/planutils/packages/forbiditerative-diverse-agl/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Forbid-Iterative diverse agile planner",
-    "description": "https://github.com/IBM/forbiditerative",
+    "name": "FI -- diverse agile planner",
+    "description": "Diverse planning focuses on producing sets of plans with a large difference between individual plans. Agile (greedy) configuration.",
+    "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "20K",
     "dependencies": ["forbiditerative"]
 }

--- a/planutils/packages/forbiditerative-diverse-sat/manifest.json
+++ b/planutils/packages/forbiditerative-diverse-sat/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Forbid-Iterative diverse satisficing planner",
-    "description": "https://github.com/IBM/forbiditerative",
+    "name": "FI -- diverse satisficing planner",
+    "description": "Diverse planning focuses on producing sets of plans with a large difference between individual plans. Satisficing configuration.",
+    "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "20K",
     "dependencies": ["forbiditerative"]
 }

--- a/planutils/packages/forbiditerative-diverse-sat/manifest.json
+++ b/planutils/packages/forbiditerative-diverse-sat/manifest.json
@@ -1,5 +1,6 @@
 {
     "name": "FI -- diverse satisficing planner",
+    "shortname": "fi-div-sat",
     "description": "Diverse planning focuses on producing sets of plans with a large difference between individual plans. Satisficing configuration.",
     "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "20K",

--- a/planutils/packages/forbiditerative-topk/manifest.json
+++ b/planutils/packages/forbiditerative-topk/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Forbid-Iterative top-k planner",
-  "description": "https://github.com/IBM/forbiditerative",
+  "name": "FI -- top-k planner",
+  "description": "A novel iterative approach to top-k planning, exploiting any cost-optimal planner and reformulating a planning task to forbid exactly the given set of solutions.",
   "install-size": "20K",
   "dependencies": ["forbiditerative"],
   "endpoint": {

--- a/planutils/packages/forbiditerative-topk/manifest.json
+++ b/planutils/packages/forbiditerative-topk/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "FI -- top-k planner",
+  "shortname": "fi-topk",
   "description": "A novel iterative approach to top-k planning, exploiting any cost-optimal planner and reformulating a planning task to forbid exactly the given set of solutions.",
   "install-size": "20K",
   "dependencies": ["forbiditerative"],

--- a/planutils/packages/forbiditerative-topq/manifest.json
+++ b/planutils/packages/forbiditerative-topq/manifest.json
@@ -1,5 +1,6 @@
 {
     "name": "FI -- unordered top-quality planner",
+    "shortname": "fi-topq",
     "description": "Iterative planner for a family of computational problems called top-quality planning, where solution validity is defined through plan quality bound rather than an arbitrary number of plans.",
     "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "20K",

--- a/planutils/packages/forbiditerative-topq/manifest.json
+++ b/planutils/packages/forbiditerative-topq/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Forbid-Iterative unordered top-q planner",
-    "description": "https://github.com/IBM/forbiditerative",
+    "name": "FI -- unordered top-quality planner",
+    "description": "Iterative planner for a family of computational problems called top-quality planning, where solution validity is defined through plan quality bound rather than an arbitrary number of plans.",
+    "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "20K",
     "dependencies": ["forbiditerative"]
 }

--- a/planutils/packages/forbiditerative/manifest.json
+++ b/planutils/packages/forbiditerative/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Forbid-Iterative (FI) Planner is an Automated PDDL based planner suite that includes planners for top-k, top-quality, and diverse computational tasks",
-    "description": "https://github.com/IBM/forbiditerative",
+    "name": "The Forbid-Iterative (FI) planning system",
+    "description": "FI includes various planning systems which obtain multiple solutions by iteratively reformulating planning tasks to restrict the set of valid plans, forbidding previously found ones.",
+    "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "41M",
     "dependencies": []
 }

--- a/planutils/packages/forbiditerative/manifest.json
+++ b/planutils/packages/forbiditerative/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "The Forbid-Iterative (FI) planning system",
-    "shortname": "fi",
+    "shortname": "fi-plan",
     "description": "FI includes various planning systems which obtain multiple solutions by iteratively reformulating planning tasks to restrict the set of valid plans, forbidding previously found ones.",
     "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "41M",

--- a/planutils/packages/forbiditerative/manifest.json
+++ b/planutils/packages/forbiditerative/manifest.json
@@ -1,5 +1,6 @@
 {
     "name": "The Forbid-Iterative (FI) planning system",
+    "shortname": "fi",
     "description": "FI includes various planning systems which obtain multiple solutions by iteratively reformulating planning tasks to restrict the set of valid plans, forbidding previously found ones.",
     "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "41M",

--- a/planutils/packages/hpddl2pddl/manifest.json
+++ b/planutils/packages/hpddl2pddl/manifest.json
@@ -1,5 +1,6 @@
 {
     "name": "HTN-Translation: translating HTN planning problems to PDDL",
+    "shortname": "htntranslation",
     "description": "A program for translating Hierarchical Task Network problems into PDDL",
     "homepage": "https://github.com/ronwalf/HTN-Translation",
     "install-size": "28M",

--- a/planutils/packages/hpddl2pddl/manifest.json
+++ b/planutils/packages/hpddl2pddl/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "HTNTranslate: Translate HPDDL to PDDL",
-    "description": "https://github.com/ronwalf/HTN-Translation",
+    "name": "HTN-Translation: translating HTN planning problems to PDDL",
+    "description": "A program for translating Hierarchical Task Network problems into PDDL",
+    "homepage": "https://github.com/ronwalf/HTN-Translation",
     "install-size": "28M",
     "dependencies": [],
     "author": "Ron Alford"

--- a/planutils/packages/kstar/manifest.json
+++ b/planutils/packages/kstar/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "K* planner for the top-k planning problem",
-  "description": "https://github.com/ctpelok77/kstar",
+  "name": "K* planner: integrating the K* algorithm into Fast Downward",
+  "description": "The first K∗ based solver for PDDL planning tasks; it is best suited for problems with very large solution set-size requirements (>1,000).",
+  "homepage": "https://github.com/ctpelok77/kstar",
   "install-size": "36M",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/lama-first/manifest.json
+++ b/planutils/packages/lama-first/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "LAMA-FIRST",
-  "description": "http://fast-downward.org/",
+  "name": "LAMA-first: satisficing planner without solution improvement",
+  "description": "LAMA-first is designed to find solutions quickly without much regard for plan cost. As its only step, it runs a greedy best-first search, skipping the subsequent refinements performed in regular LAMA.",
   "install-size": "20K",
   "dependencies": [
     "downward"

--- a/planutils/packages/lama/manifest.json
+++ b/planutils/packages/lama/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "LAMA",
-  "description": "http://fast-downward.org/",
+  "name": "LAMA: guiding cost-based anytime planning with landmarks",
+  "description": "As a first step, it runs a greedy best-first search, aimed at finding a solution as quickly as possible. Once a plan is found, it searches for progressively better solutions.",
   "install-size": "20K",
   "dependencies": [
     "downward"

--- a/planutils/packages/lapkt/install
+++ b/planutils/packages/lapkt/install
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-singularity pull --name lapkt.sif https://github.com/nirlipo/BFWS-public/releases/download/planutils_singularity/bfws.sif
+singularity pull --name bfws.sif https://github.com/nirlipo/BFWS-public/releases/download/planutils_singularity/bfws.sif

--- a/planutils/packages/lapkt/manifest.json
+++ b/planutils/packages/lapkt/manifest.json
@@ -1,6 +1,8 @@
 {
-  "name": "LAPKT (Lightweight Automated Planning ToolKiT)",
-  "description": "This package contains the source code of the planners that participated in IPC-9, 2018. It contains the winner of the Agile-Track, and runner-up of tha SAT-track.",
+  "name": "BFWS: Best-First Width Search",
+  "shortname": "bfws",
+  "description": "BFWS combines goal-oriented search (heuristic exploitation) and width-based search (structural exploration) in classical planning, implemented using the LAPKT toolkit.",
+  "homepage": "https://github.com/nirlipo/BFWS-public",
   "install-size": "184M",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/lapkt/run
+++ b/planutils/packages/lapkt/run
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-singularity run -e $(dirname $0)/lapkt.sif $@
+singularity run -e $(dirname $0)/bfws.sif $@

--- a/planutils/packages/lpg-td/manifest.json
+++ b/planutils/packages/lpg-td/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "LPG-td",
-  "description": "https://lpg.unibs.it/lpg/index.html",
+  "name": "LPG-td: a fully automated temporal planner for PDDL2.2 domains",
+  "description": "LPG (Local search for Planning Graphs) is a planner that handles numerical quantities and durations. LPG-td is an extension to handle the new features of PDDL2.2.",
+  "homepage": "https://lpg.unibs.it/lpg/index.html",
   "install-size": "2.2M",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/machetli/manifest.json
+++ b/planutils/packages/machetli/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Machetli",
-    "description": "Machetli is a Python package for reproducing characteristics of a program (such as bugs) with modified instances. It is meant to be helpful for debugging complex programs and narrowing down where specific behaviors are caused. Currently, Machetli handles instances for automated planners, specified either in PDDL or in the SAS+ format used by Fast Downward but adding support for other file formats is easy.",
+    "name": "Machetli: helping debugging complex programs",
+    "description": "A Python package for reproducing characteristics of a program (such as bugs) with modified instances.",
+    "homepage": "https://machetli.readthedocs.io/en/latest",
     "install-size": "3MB",
     "dependencies": []
 }

--- a/planutils/packages/macq/manifest.json
+++ b/planutils/packages/macq/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "MACQ",
-    "description": "A collection of tools for planning-like action model acquisition from state trace data",
+    "name": "MAcq: The Model Acquisition Toolkit",
+    "description": "This library is a collection of tools for planning-like action model acquisition from state trace data. It contains a reimplementation from many existing works, and generalizes some of them to new settings.",
+    "homepage": "https://github.com/AI-Planning/macq",
     "install-size": "74K",
     "dependencies": []
 }

--- a/planutils/packages/metric-ff/manifest.json
+++ b/planutils/packages/metric-ff/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "Metric Fast-Forward",
-  "description": "https://fai.cs.uni-saarland.de/hoffmann/metric-ff.html",
+  "name": "Metric Fast-Forward: extended with numerical state variables",
+  "description": "The system is an extension of the FF planner to numerical state variables, more precisely to PDDL2.1 level 2.",
+  "homepage": "https://fai.cs.uni-saarland.de/hoffmann/metric-ff.html",
   "install-size": "1.8M",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/optic/manifest.json
+++ b/planutils/packages/optic/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "The OPTIC temporal planner",
-  "description": "The OPTIC temporal planner (see https://github.com/roveri-marco/optic)",
+  "name": "OPTIC: Optimising Preferences and Time-Dependent Costs",
+  "description": "OPTIC is a temporal planner for use in problems where plan cost is determined by preferences or time-dependent goal-collection costs.",
+  "homepage": "https://github.com/roveri-marco/optic",
   "install-size": "297MB",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/planning.domains/manifest.json
+++ b/planutils/packages/planning.domains/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Planning.Domains API",
-    "description": "API Tools for Planning.Domains",
+    "name": "planning.domains API tools",
+    "description": "This repository houses a collection of tools and scripts for interacting with the interface found at api.planning.domains. More information can be found on that website.",
+    "homepage": "https://github.com/AI-Planning/api-tools",
     "install-size": "368K",
     "dependencies": []
 }

--- a/planutils/packages/popf/manifest.json
+++ b/planutils/packages/popf/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "The POPF temporal planner",
-    "description": "The POPF temporal planner (see https://github.com/roveri-marco/popf)",
+    "name": "POPF: Partial Order Planning Forwards",
+    "description": "POPF is forwards-chaining temporal planner with linear continuous effects, inspited by partial-order planning. This version (POPF2) introduces any-time search, allowing it to optimise solution quality.",
+    "homepage": "https://github.com/roveri-marco/popf",
     "install-size": "297MB",
     "dependencies": []
 }

--- a/planutils/packages/poprp/manifest.json
+++ b/planutils/packages/poprp/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "PO-PRP",
-    "description": "https://github.com/QuMuLab/planner-for-relevant-policies/wiki/PO-PRP",
+    "name": "PO-PRP: Planning for Relevant Policies -- partial observability",
+    "description": "A version of PRP capable of solving non-deterministic planning problems with partial observability and sensing. The process is always sound, and complete for simple contingent problems.",
+    "homepage": "https://github.com/QuMuLab/planner-for-relevant-policies/wiki/PO-PRP",
     "install-size": "63M",
     "dependencies": []
 }

--- a/planutils/packages/prp/manifest.json
+++ b/planutils/packages/prp/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "PRP",
-    "description": "https://github.com/QuMuLab/planner-for-relevant-policies",
+    "name": "PRP: Planning for Relevant Policies -- full observability",
+    "description": "Planner for Relevant Policies is a state-of-the-art fully observable non-deterministic (FOND) planner that supports conditional effects.",
+    "homepage": "https://github.com/QuMuLab/planner-for-relevant-policies/wiki",
     "install-size": "41M",
     "dependencies": []
 }

--- a/planutils/packages/pyperplan/manifest.json
+++ b/planutils/packages/pyperplan/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Pyperplan",
-    "description": "https://github.com/aibasel/pyperplan/",
+    "name": "Pyperplan: a lightweight STRIPS planner written in Python",
+    "description": "Please note that Pyperplan deliberately prefers clean code over fast code. It is designed to be used as a teaching or prototyping tool, and does not offer state-of-the-art performance.",
+    "homepage": "https://github.com/aibasel/pyperplan",
     "install-size": "16K",
     "dependencies": [],
     "endpoint": {

--- a/planutils/packages/scorpion/manifest.json
+++ b/planutils/packages/scorpion/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Scorpion",
-    "description": "https://github.com/jendrikseipp/scorpion",
+    "name": "Scorpion: optimal classical planner based on saturated cost partitioning",
+    "description": "Scorpion is an optimal classical planner based on the Fast Downward planning system that uses saturated cost partitioning to combine multiple abstraction heuristics.",
+    "homepage": "https://github.com/jendrikseipp/scorpion",
     "install-size": "40M",
     "dependencies": []
 }

--- a/planutils/packages/smtplan/manifest.json
+++ b/planutils/packages/smtplan/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "SMTPlan+",
-    "description": "SMTPlan+ is a planner for hybrid systems. http://kcl-planning.github.io/SMTPlan/",
+    "name": "SMTPlan+: a planner for hybrid systems",
+    "description": "SMTPlan+ supports all the features of PDDL+, including exogenous events and continuous processes with nonlinear polynomial change.",
+    "homepage": "http://kcl-planning.github.io/SMTPlan",
     "install-size": "148M",
     "dependencies": []
 }

--- a/planutils/packages/symk/manifest.json
+++ b/planutils/packages/symk/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "Symk is a state-of-the-art optimal and top-k planner.",
-  "description": "https://github.com/speckdavid/symk",
+  "name": "Sym-k: symbolic top-k planning",
+  "description": "A novel approach to top-k planning, called sym-k, which is based on symbolic search. The objective of top-k planning is to determine a set of k different plans with lowest cost for a given planning task.",
+  "homepage": "https://github.com/speckdavid/symk",
   "install-size": "40M",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/tarski/manifest.json
+++ b/planutils/packages/tarski/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "Tarski",
-    "description": "Tarski is a framework for the specification, modeling and manipulation of AI planning problems.",
+    "name": "Tarski: an AI planning modeling framework",
+    "description": "Tarski is a framework for the specification, modeling and manipulation of AI planning problems, with modules to perform transformations, reachability analysis, grounding, and problem reformulations.",
+    "homepage": "https://tarski.readthedocs.io",
     "install-size": "16K",
     "dependencies": []
 }

--- a/planutils/packages/tfd/manifest.json
+++ b/planutils/packages/tfd/manifest.json
@@ -1,6 +1,7 @@
 {
-  "name": "The TFD temporal planner",
-  "description": "The TFD temporal planner (see https://github.com/roveri-marco/tfd)",
+  "name": "Temporal Fast Downward planning system",
+  "description": "TFD is based on the Fast Downward planning system and uses an adaptation of the context-enhanced additive heuristic to guide the search in the temporal state space induced by the given planning problem.",
+  "homepage": "https://gki.informatik.uni-freiburg.de/tools/tfd/",
   "install-size": "145MB",
   "dependencies": [],
   "endpoint": {

--- a/planutils/packages/val/manifest.json
+++ b/planutils/packages/val/manifest.json
@@ -1,6 +1,7 @@
 {
-    "name": "VAL",
-    "description": "https://github.com/KCL-Planning/VAL",
+    "name": "VAL: The plan validation system",
+    "description": "Tools for parsing, validating, and analyzing plans and planning models.",
+    "homepage": "https://github.com/KCL-Planning/VAL",
     "install-size": "3M",
     "dependencies": []
 }


### PR DESCRIPTION
This PR will:

##### Fix minor issues after activating the environment
* Fix the problem where the shell prompt prefix interferes with the line-break in the terminal
* Clear the input history when activating 

##### Make the package listing more pip-like
* Sort the installed and available packages alphabetically
* Extend the `description` for each supported planner
* Also make the `name` field more descriptive
* Add a `homepage` field for each supported planner
* Add the new command `planutils show <package>`
* Other minor improvements

##### Implement the `shortname` feature
Quoting from [planutils/packages/README.md](https://github.com/AI-Planning/planutils/tree/main/planutils/packages):
> `shortname` specified in the `manifest.json` file will be used for the command-line invocation ...
* All planners with long, clunky names (e.g. forbiditerative-diverse-agl) get an optional `shortname` field in the manifest.
* This shortname can be used as an alternative for the sake of `run`, `install`, `show` etc.
* As specified, `shortname` will **replace** the case where `run` is omitted:
  - For "quick" CLI invocations, it makes sense to keep it short
  - For scripting, the full name can still be used in conjunction with `planutils run ...`

