### PR TITLE
Revert shortnames

### DIFF
--- a/planutils/__init__.py
+++ b/planutils/__init__.py
@@ -30,9 +30,6 @@ def setup():
 
     print("Installing package scripts...")
     for p in PACKAGES:
-        # TODO: RENAME EXECUTABLE HERE
-        try: s = PACKAGES[p]['shortname']
-        except: s = p
         if PACKAGES[p]['runnable']:
             script  = "#!/bin/bash\n"
             script += "if $(planutils check-installed %s)\n" % p
@@ -60,9 +57,9 @@ def setup():
             script += "  fi\n"
             script += "  echo\n"
             script += "fi\n"
-            with open(os.path.join(os.path.expanduser('~'), '.planutils', 'bin', s), 'w') as f:
+            with open(os.path.join(os.path.expanduser('~'), '.planutils', 'bin', p), 'w') as f:
                 f.write(script)
-            os.chmod(os.path.join(os.path.expanduser('~'), '.planutils', 'bin', s), 0o0755)
+            os.chmod(os.path.join(os.path.expanduser('~'), '.planutils', 'bin', p), 0o0755)
 
 
     print("\nAll set! Use \"planutils activate\" to activate the environment, or run through \"planutils\" directly.\n")

--- a/planutils/package_installation.py
+++ b/planutils/package_installation.py
@@ -113,9 +113,8 @@ def package_list():
         print()
 
     available_names = []
-    for p in PACKAGES:
-        try: available_names.append(PACKAGES[p]['shortname'])
-        except: available_names.append(p)
+    for p in PACKAGES: 
+        available_names.append(p)
     if available_names:
         print("%-*s %s" % (width_name, 'Available', 'Summary'))
         print("%-*s %s" % (width_name, ''.ljust(width_name,'-'), ''.ljust(width_desc,'-')))

--- a/planutils/packages/forbiditerative/manifest.json
+++ b/planutils/packages/forbiditerative/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "The Forbid-Iterative (FI) planning system",
-    "shortname": "fi-plan",
+    "shortname": "fi",
     "description": "FI includes various planning systems which obtain multiple solutions by iteratively reformulating planning tasks to restrict the set of valid plans, forbidding previously found ones.",
     "homepage": "https://github.com/IBM/forbiditerative",
     "install-size": "41M",


### PR DESCRIPTION
Resolves issue #117. This will revert the usage of 'shortnames' attribute as an alternative to the folder name in the package installation script, effectively reverting 38c711be4771ee8e3cdfc29f6609617ba08338ea and 065d4ca732b74fa53b7aa67a696c8dec7458353a. This will mitigate the clumsy mistakes introduced in PR #115. 

As mentioned, I will submit another PR for that feature when I have tested it more rigorously. We could then have a discussion about the particular package names before you merge.

However, a looking at the changed files in da4f9484d752931c5b4dbee9f32bb159e825fe47, we can see that the only functions changed are `package_list()` and `package_info(...)`. 

I have not removed the prompt for installing missing packages. I will look into it further