### PR TITLE
Improved scripting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ run a number of the planners (all those that are based on singularity), you will
 to run the docker with the `--privileged` option.
 
 **Run the planutils container**
-```
+```sh
 docker run -it --privileged aiplanning/planutils:latest bash
 ```
 
 **Active the planutils environment**
-```
+```sh
 planutils activate
 ```
 
@@ -24,20 +24,20 @@ This means that in order to run the latest release, it is not necessary to clone
 ## 2. Making your own image with desired solvers
 
 Below is an example for creating your own Dockerfile based on the latest release, with pre-installed solvers
-```
+```sh
 FROM aiplanning/planutils:latest
 
 # Install solvers and tools
-RUN yes | planutils install val
-RUN yes | planutils install planning.domains
-RUN yes | planutils install popf
-RUN yes | planutils install optic
-RUN yes | planutils install smtplan
+RUN planutils install -y val
+RUN planutils install -y planning.domains
+RUN planutils install -y popf
+RUN planutils install -y optic
+RUN planutils install -y smtplan
 ```
 
 ## 3. Running planutils from source
 You can also run the latest unreleased version. For this, clone this repository and run 
-```
+```sh
 docker build . -t planutils-dev:latest
 ```
 
@@ -45,7 +45,7 @@ docker build . -t planutils-dev:latest
 
 ### Example of currently working functionality
 
-```bash
+```
 $ lama domain.pddl problem.pddl
 
 Package not installed!
@@ -70,7 +70,7 @@ $
 
 ### Example of upcoming functionality
 
-```bash
+```
 $ planutils install ipc-2018
 Installing planners
 This will require 3Gb of storage. Proceed? [Y/n]
@@ -111,7 +111,7 @@ Please create a manifest file named `manifest_compact.json` if you want to use p
 You can also create a `manifest.json` file directly if you don't need the template.
 
 **Manifest Example**
-```
+```json
 {
     "name": "LAMA-FIRST",
     "description": "http://fast-downward.org/",
@@ -148,7 +148,7 @@ You can also create a `manifest.json` file directly if you don't need the templa
 
 There are four types of Args: `file`, `int`, `string` and,`categorical`. You can add default value for `int`,`string`, and `categorical` arguments
 
-```
+```json
  "args": [
     {
         "name": "domain",
@@ -190,7 +190,7 @@ There are four types of Args: `file`, `int`, `string` and,`categorical`. You can
 There are three types of return data: `generic`, `json` and `log`. The `generic` type should be used for all the text based result, the `log` type should be used for planner like Optic and Tfd which didn't generate a proper plan, and the type `json` should used for plan in JSON format.
 
 For the value of `files`, you will have to write a [glob](https://docs.python.org/3/library/glob.html) pattern. Planning-as-service backend uses `glob` libary to find and return all the files that matched. 
-```
+```json
 "return": {
                     "type": "generic/log/json",
                     "files": "*plan*"

--- a/bin/planutils
+++ b/bin/planutils
@@ -1,28 +1,11 @@
-#!/bin/bash -i
+#!/bin/bash
 
 # Check if the first argument is "activate", and set the PATH environment variable accordingly
 if [ "$1" = "activate" ]; then
-
-    # Environment variables
-    export PLANUTILS_PREFIX="~/.planutils"
-    export PATH="$PATH:$PLANUTILS_PREFIX/bin"
-
-    # Add a blue coloured shell prompt prefix (planutils)
-    export PS1="(\[\e[1;34m\]planutils\[\e[0m\]) $PS1"
-
-    echo
-    echo "   Entering planutils environment..."
-    echo
-
-    # Enter the shell
-    $SHELL --init-file <(echo "export PS1=\"$PS1\"")
-
-    # Clear history
-    history -cw
+    planutils_activate
 
 # Else, call planutils via python
 else
     python3 -c "import planutils; planutils.main()" "$@"
     exit $?
 fi
-

--- a/bin/planutils_activate
+++ b/bin/planutils_activate
@@ -1,0 +1,15 @@
+#!/bin/bash -i
+
+# Environment variables
+export PLANUTILS_PREFIX="~/.planutils"
+export PATH="$PATH:$PLANUTILS_PREFIX/bin"
+
+# Add a blue coloured shell prompt prefix (planutils)
+export PS1="(\[\e[1;34m\]planutils\[\e[0m\]) $PS1"
+
+echo
+echo "   Entering planutils environment..."
+echo
+
+# Enter the shell
+$SHELL --init-file <(echo "export PS1=\"$PS1\"")

--- a/planutils/__init__.py
+++ b/planutils/__init__.py
@@ -16,11 +16,11 @@ def minimal_setup():
         settings.save({'installed': []})
 
 
-def setup():
+def setup(forced=False):
 
     if setup_done():
-        print("\nError: planutils is already setup. Setting up again will wipe all cached packages and settings.")
-        if input("  Proceed? [y/N] ").lower() in ['y', 'yes']:
+        print("\nWarning: planutils is already setup. Setting up again will wipe all cached packages and settings.")
+        if forced or input("  Proceed? [y/N] ").lower() in ['y', 'yes']:
             os.system("rm -rf %s" % os.path.join(os.path.expanduser('~'), '.planutils'))
         else:
             return
@@ -101,6 +101,7 @@ def main():
 
     parser_list = subparsers.add_parser('list', help='list the available packages')
     parser_setup = subparsers.add_parser('setup', help='setup planutils for current user')
+    parser_setup.add_argument('-f', '--force', help='force setting up again (will wipe all cached packages and settings)', action='store_true')
     parser_upgrade = subparsers.add_parser('upgrade', help='upgrade all of the installed packages')
 
     parser_show = subparsers.add_parser('show', help='show details about a particular package')
@@ -109,7 +110,7 @@ def main():
     args = parser.parse_args()
 
     if 'setup' == args.command:
-        setup()
+        setup(args.force)
         return
     else:
         minimal_setup()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(name='planutils',
       author_email='',
       license='MIT',
       packages=['planutils'],
-      scripts=['bin/planutils'],
+      scripts=['bin/planutils','bin/planutils_activate'],
       classifiers=[
           "Programming Language :: Python :: 3",
           "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Hello again ;)
Reconnecting to the discussion we had [here](https://github.com/AI-Planning/planutils/issues/117). I am proposing minor changes to improve the quality of scripting with planutils.

This PR will do the following. 
* Remove the `-i` flag from `bin/planutils`. This will mean that `planutils`commands will not be run in interactive mode. This means these commands will not be written to the command history. Additionally, this will fix the warnings
  ```
  bash: cannot set terminal process group (-1): Inappropriate ioctl for device
  bash: no job control in this shell
  ```
  which arise when calling `planutils` commands from script contexts without stdin (like docker build for instance).
* In order to preserve the interactive `planutils activate` environment, this is moved into its own script—which has the `-i` flag.
* Additionally, the `planutils setup` is provided with a `--force` flag, which allows it to be called in non-interactive shells even if it has been called before. 
* Finally, the README provides a more correct on how to interactively use planutils, and is lightly touched up with syntax highlighting