### PR TITLE
Handle ENHSP-2020 returned plans as logs

### DIFF
--- a/planutils/packages/enhsp-2020/manifest.json
+++ b/planutils/packages/enhsp-2020/manifest.json
@@ -8,7 +8,11 @@
     "services": {
       "solve": {
         "template": "planner",
-        "call":"{package_name} -o {domain} -f {problem} >> plan"
+        "call":"{package_name} -o {domain} -f {problem} >> plan",
+        "return": {
+          "type": "log",
+          "files": "*plan*"
+        }
       }
 
     }


### PR DESCRIPTION
Output plan is not compliant with our current adaptor in the solver online, so we need to change it to parse it as a log file.

Relevant code that parses plan files  returned a structured json file: https://github.com/AI-Planning/planning-as-a-service/blob/master/server/api/adaptor/planning_editor_adaptor/adaptor.py#L41

Otherwise, enhsp-2020 returns the following error:

```usage: planutils [-h] {install,uninstall,run,remote,remote-list,check-installed,server,list,setup,upgrade,configure,show} ... planutils: error: unrecognized arguments: -o domain -f problem ', 'call': 'timeout 30 planutils run enhsp-2020 -o domain -f problem >> plan'```

Test session for the editor: https://editor.planning.domains/#read_session=5FYdqT4OKG 

Once this PR is merged, we need to update the check that the update in planutils propagates to docker, and the online server service. 

In the future we may want to add a parser for temporal and numeric plans.