### PR TITLE
Add preprocessor: EAS (Enhanced Action Splitter)

### DIFF
--- a/planutils/packages/eas/install
+++ b/planutils/packages/eas/install
@@ -14,6 +14,7 @@ fi
 
 git clone https://github.com/melahi/enhanced-action-splitter.git
 cd enhanced-action-splitter
+pypy3 -m pip install setuptools --upgrade
 pypy3 -m pip install -r requirements.txt
 mv split.py split
 mv merge_plan.py merge_plan

--- a/planutils/packages/eas/install
+++ b/planutils/packages/eas/install
@@ -8,6 +8,7 @@ then
     exec sudo "$0" "$@"
     exit $?
   fi
+  apt update
   apt install -y pypy3-dev
 fi
 

--- a/planutils/packages/eas/install
+++ b/planutils/packages/eas/install
@@ -11,7 +11,7 @@ then
   apt install -y pypy3-dev
 fi
 
-git clone git@github.com:melahi/enhanced-action-splitter.git
+git clone https://github.com/melahi/enhanced-action-splitter.git
 cd enhanced-action-splitter
 pypy3 -m pip install -r requirements.txt
 mv split.py split

--- a/planutils/packages/eas/install
+++ b/planutils/packages/eas/install
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if ! (dpkg-query -s pypy3-dev &>/dev/null)
+then
+  if [ "$UID" -ne 0 ]
+  then
+    echo "installation requires root access"
+    exec sudo "$0" "$@"
+    exit $?
+  fi
+  apt install -y pypy3-dev
+fi
+
+git clone git@github.com:melahi/enhanced-action-splitter.git
+cd enhanced-action-splitter
+pypy3 -m pip install -r requirements.txt
+mv split.py split
+mv merge_plan.py merge_plan

--- a/planutils/packages/eas/manifest.json
+++ b/planutils/packages/eas/manifest.json
@@ -1,0 +1,6 @@
+{
+    "name": "Enhanced Action Splitter (EAS)",
+    "description": "Enhanced Action Splitter (EAS) efficiently splits PDDL action schemas into smaller actions suitable for grounding. This is particularly helpful when the number of grounded actions for action schemas becomes too large for grounding-based planners to handle, effectively enabling them to solve problems they otherwise couldn't.",
+    "install-size": "920K",
+    "dependencies": []
+}

--- a/planutils/packages/eas/run
+++ b/planutils/packages/eas/run
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+if [[ "$1" == "" || "$1" == "-h" || "$1" == "--help" || "$1" == "help" ]]
+then
+  echo
+  echo "eas [help|<command>]"
+  echo
+  echo "<command> can be:"
+  echo "    split: Produces the split version of the problem instance."
+  echo "    merge_plan: Merges the plan for the split instance to construct a solution for the original problem"
+  echo
+  echo "To get specific help for <command>:"
+  echo "eas <command> -h"
+  echo
+else
+  $(dirname "$0")/enhanced-action-splitter/"$1" ${@:2}
+fi

--- a/planutils/packages/eas/uninstall
+++ b/planutils/packages/eas/uninstall
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -rf enhanced-action-splitter/


### PR DESCRIPTION
This pull request adds support for the Enhanced Action Splitter (EAS) preprocessor. The package name is `eas`, and it supports two commands:

* `split`: which produces the split instance of the PDDL problem
* `merge_plan`: which merges the split plan

The main repository is: https://github.com/melahi/enhanced-action-splitter/